### PR TITLE
group papers by publication year

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,77 +13,83 @@ format:
 ```
 
 ## Papers
+### 2025
+- [OmniRL: In-Context Reinforcement Learning by Large-Scale Meta-Training in Randomized Worlds](https://arxiv.org/abs/2502.02869)
+  - Wang, Fan, Pengtao Shao, Yiming Zhang, Bo Yu, Shaoshan Liu, Ning Ding, Yang Cao, Yu Kang, and Haifeng Wang
 - [A **Survey** of In-Context Reinforcement Learning](https://arxiv.org/abs/2502.07978)
   - Amir Moeini, Jiuqi Wang, Jacob Beck, Ethan Blaser, Shimon Whiteson, Rohan Chandra, Shangtong Zhang
-- [In-context Reinforcement Learning with Algorithm Distillation](https://arxiv.org/abs/2210.14215)
-  - Michael Laskin, Luyu Wang, Junhyuk Oh, Emilio Parisotto, Stephen Spencer, Richie Steigerwald, DJ Strouse, Steven Hansen, Angelos Filos, Ethan Brooks, Maxime Gazeau, Himanshu Sahni, Satinder Singh, Volodymyr Mnih
-- [Supervised Pretraining Can Learn In-Context Reinforcement Learning](https://arxiv.org/abs/2306.14892)
-  - Jonathan N. Lee, Annie Xie, Aldo Pacchiano, Yash Chandak, Chelsea Finn, Ofir Nachum, Emma Brunskill
-- [Vintix: Action Model via In-Context Reinforcement Learning](https://arxiv.org/abs/2501.19400)
-  - Andrey Polubarov, Nikita Lyubaykin, Alexander Derevyagin, Ilya Zisman, Denis Tarasov, Alexander Nikulin, Vladislav Kurenkov
-- [Emergence of In-Context Reinforcement Learning from Noise Distillation](https://arxiv.org/abs/2312.12275)
-  - Ilya Zisman, Vladislav Kurenkov, Alexander Nikulin, Viacheslav Sinii, Sergey Kolesnikov 
-- [In-Context Reinforcement Learning for Variable Action Spaces](https://arxiv.org/abs/2312.13327)
-  - Viacheslav Sinii, Alexander Nikulin, Vladislav Kurenkov, Ilya Zisman, Sergey Kolesnikov
-- [In-Context Reinforcement Learning Without Optimal Action Labels](https://openreview.net/forum?id=8Dey9wo2qA)
-  - Juncheng Dong, Moyang Guo, Ethan X Fang, Zhuoran Yang, Vahid Tarokh
 - [Yes, Q-learning Helps Offline In-Context RL](https://arxiv.org/abs/2502.17666)
   - Denis Tarasov, Alexander Nikulin, Ilya Zisman, Albina Klepach, Andrei Polubarov, Nikita Lyubaykin, Alexander Derevyagin, Igor Kiselev, Vladislav Kurenkov
-- [XLand-100B: A Large-Scale Multi-Task Dataset for In-Context Reinforcement Learning](https://arxiv.org/abs/2406.08973)
-  - Alexander Nikulin, Ilya Zisman, Alexey Zemtsov, Viacheslav Sinii, Vladislav Kurenkov, Sergey Kolesnikov
-- [ReLIC: A Recipe for 64k Steps of In-Context Reinforcement Learning for Embodied AI](https://arxiv.org/abs/2410.02751)
-  - Ahmad Elawady, Gunjan Chhablani, Ram Ramrakhya, Karmesh Yadav, Dhruv Batra, Zsolt Kira, Andrew Szot
-- [Sparse Autoencoders Reveal Temporal Difference Learning in Large Language Models](https://arxiv.org/abs/2410.01280)
-  - Can Demircan, Tankred Saanum, Akshay K. Jagadish, Marcel Binz, Eric Schulz
-- [AMAGO: Scalable In-Context Reinforcement Learning for Adaptive Agents](https://arxiv.org/abs/2310.09971)
-  - Jake Grigsby, Linxi Fan, Yuke Zhu
+- [Vintix: Action Model via In-Context Reinforcement Learning](https://arxiv.org/abs/2501.19400)
+  - Andrey Polubarov, Nikita Lyubaykin, Alexander Derevyagin, Ilya Zisman, Denis Tarasov, Alexander Nikulin, Vladislav Kurenkov
+
+### 2024
+- [LMAct: A Benchmark for In-Context Imitation Learning with Long Multimodal Demonstrations](https://arxiv.org/abs/2412.01441)
+  - Anian Ruoss, Fabio Pardo, Harris Chan, Bonnie Li, Volodymyr Mnih, Tim Genewein
+- [Meta-Reinforcement Learning Robust to Distributional Shift Via Performing Lifelong In-Context Learning](https://proceedings.mlr.press/v235/xu24o.html)
+  - Tengye Xu, Zihao Li, Qinyuan Ren
 - [AMAGO-2: Breaking the Multi-Task Barrier in Meta-Reinforcement Learning with Transformers](https://arxiv.org/abs/2411.11188)
   - Jake Grigsby, Justin Sasek, Samyak Parajuli, Daniel Adebi, Amy Zhang, Yuke Zhu
-- [Transformers as Decision Makers: Provable In-Context Reinforcement Learning via Supervised Pretraining](https://arxiv.org/abs/2310.08566)
-  - Licong Lin, Yu Bai, Song Mei
-- [Structured State Space Models for In-Context Reinforcement Learning](https://arxiv.org/abs/2303.03982)
-  - Chris Lu, Yannick Schroecker, Albert Gu, Emilio Parisotto, Jakob Foerster, Satinder Singh, Feryal Behbahani
 - [LLMs Are In-Context Reinforcement Learners](https://arxiv.org/abs/2410.05362)
   - Giovanni Monea, Antoine Bosselut, Kianté Brantley, Yoav Artzi
 - [EVOLvE: Evaluating and Optimizing LLMs For Exploration](https://arxiv.org/abs/2410.06238)
   - Allen Nie, Yi Su, Bo Chang, Jonathan N. Lee, Ed H. Chi, Quoc V. Le, Minmin Chen
-- [In-Context Decision Transformer: Reinforcement Learning via Hierarchical Chain-of-Thought](https://arxiv.org/abs/2405.20692)
-  - Sili Huang, Jifeng Hu, Hechang Chen, Lichao Sun, Bo Yang
-- [Decision Mamba: Reinforcement Learning via Hybrid Selective Sequence Modeling](https://arxiv.org/abs/2406.00079)
-  - Sili Huang, Jifeng Hu, Zhejian Yang, Liwei Yang, Tao Luo, Hechang Chen, Lichao Sun, Bo Yang
+- [Sparse Autoencoders Reveal Temporal Difference Learning in Large Language Models](https://arxiv.org/abs/2410.01280)
+  - Can Demircan, Tankred Saanum, Akshay K. Jagadish, Marcel Binz, Eric Schulz
+- [ReLIC: A Recipe for 64k Steps of In-Context Reinforcement Learning for Embodied AI](https://arxiv.org/abs/2410.02751)
+  - Ahmad Elawady, Gunjan Chhablani, Ram Ramrakhya, Karmesh Yadav, Dhruv Batra, Zsolt Kira, Andrew Szot
 - [Retrieval-Augmented Decision Transformer: External Memory for In-context RL](https://arxiv.org/abs/2410.07071)
   - Thomas Schmied, Fabian Paischer, Vihang Patil, Markus Hofmarcher, Razvan Pascanu, Sepp Hochreiter
-- [Human-Timescale Adaptation in an Open-Ended Task Space](https://arxiv.org/abs/2301.07608)
-  - Adaptive Agent Team, Jakob Bauer, Kate Baumli, Satinder Baveja, Feryal Behbahani, Avishkar Bhoopchand, Nathalie Bradley-Schmieg, Michael Chang, Natalie Clay, Adrian Collister, Vibhavari Dasagi, Lucy Gonzalez, Karol Gregor, Edward Hughes, Sheleem Kashem, Maria Loks-Thompson, Hannah Openshaw, Jack Parker-Holder, Shreya Pathak, Nicolas Perez-Nieves, Nemanja Rakicevic, Tim Rocktäschel, Yannick Schroecker, Jakub Sygnowski, Karl Tuyls, Sarah York, Alexander Zacherl, Lei Zhang
-- [Generalization to New Sequential Decision Making Tasks with In-Context Learning](https://arxiv.org/abs/2312.03801)
-  - Sharath Chandra Raparthy, Eric Hambro, Robert Kirk, Mikael Henaff, Roberta Raileanu
-- [Large Language Models can Implement Policy Iteration](https://arxiv.org/abs/2210.03821)
-  - Ethan Brooks, Logan Walls, Richard L. Lewis, Satinder Singh
-- [Learning How to Infer Partial MDPs for In-Context Adaptation and Exploration](https://arxiv.org/abs/2302.04250)
-  - Chentian Jiang, Nan Rosemary Ke, Hado van Hasselt
-- [Towards General-Purpose In-Context Learning Agents](https://openreview.net/forum?id=zDTqQVGgzH)
-  - Louis Kirsch, James Harrison, C. Daniel Freeman, Jascha Sohl-Dickstein, Jürgen Schmidhuber
-- [Large Language Models as General Pattern Machines](https://arxiv.org/abs/2307.04721)
-  - Suvir Mirchandani, Fei Xia, Pete Florence, Brian Ichter, Danny Driess, Montserrat Gonzalez Arenas, Kanishka Rao, Dorsa Sadigh, Andy Zeng
-- [Cross-Episodic Curriculum for Transformer Agents](https://arxiv.org/abs/2310.08549)
-  - Lucy Xiaoyang Shi, Yunfan Jiang, Jake Grigsby, Linxi "Jim" Fan, Yuke Zhu
-- [First-Explore, then Exploit: Meta-Learning Intelligent Exploration](https://arxiv.org/abs/2307.02276)
-  - Ben Norman, Jeff Clune
-- [Meta-Reinforcement Learning Robust to Distributional Shift Via Performing Lifelong In-Context Learning](https://proceedings.mlr.press/v235/xu24o.html)
-  - Tengye Xu, Zihao Li, Qinyuan Ren
-- [Artificial Generational Intelligence: Cultural Accumulation in Reinforcement Learning](https://arxiv.org/abs/2406.00392)
-  - Jonathan Cook, Chris Lu, Edward Hughes, Joel Z. Leibo, Jakob Foerster
-- [Large Language Models As Evolution Strategies](https://arxiv.org/abs/2402.18381)
-  - Robert Tjarko Lange, Yingtao Tian, Yujin Tang
-- [Can Large Language Models Explore In-Context?](https://arxiv.org/abs/2403.15371)
-  - Akshay Krishnamurthy, Keegan Harris, Dylan J. Foster, Cyril Zhang, Aleksandrs Slivkins
 - [SAD: State-Action Distillation for In-Context Reinforcement Learning under Random Policies](https://arxiv.org/abs/2410.19982)
   - Weiqin Chen, Santiago Paternain
+- [Artificial Generational Intelligence: Cultural Accumulation in Reinforcement Learning](https://arxiv.org/abs/2406.00392)
+  - Jonathan Cook, Chris Lu, Edward Hughes, Joel Z. Leibo, Jakob Foerster
+- [XLand-100B: A Large-Scale Multi-Task Dataset for In-Context Reinforcement Learning](https://arxiv.org/abs/2406.08973)
+  - Alexander Nikulin, Ilya Zisman, Alexey Zemtsov, Viacheslav Sinii, Vladislav Kurenkov, Sergey Kolesnikov
+- [Decision Mamba: Reinforcement Learning via Hybrid Selective Sequence Modeling](https://arxiv.org/abs/2406.00079)
+  - Sili Huang, Jifeng Hu, Zhejian Yang, Liwei Yang, Tao Luo, Hechang Chen, Lichao Sun, Bo Yang
 - [Pretraining Decision Transformers with Reward Prediction for In-Context Multi-task Structured Bandit Learning](https://arxiv.org/abs/2406.05064)
   - Subhojyoti Mukherjee, Josiah P. Hanna, Qiaomin Xie, Robert Nowak
 - [Transformers Learn Temporal Difference Methods for In-Context Reinforcement Learning](https://arxiv.org/abs/2405.13861)
   - Jiuqi Wang, Ethan Blaser, Hadi Daneshmand, Shangtong Zhang
-- [OmniRL: In-Context Reinforcement Learning by Large-Scale Meta-Training in Randomized Worlds](https://arxiv.org/abs/2502.02869)
-  - Wang, Fan, Pengtao Shao, Yiming Zhang, Bo Yu, Shaoshan Liu, Ning Ding, Yang Cao, Yu Kang, and Haifeng Wang
-- [LMAct: A Benchmark for In-Context Imitation Learning with Long Multimodal Demonstrations](https://arxiv.org/abs/2412.01441)
-  - Anian Ruoss, Fabio Pardo, Harris Chan, Bonnie Li, Volodymyr Mnih, Tim Genewein
+- [In-Context Decision Transformer: Reinforcement Learning via Hierarchical Chain-of-Thought](https://arxiv.org/abs/2405.20692)
+  - Sili Huang, Jifeng Hu, Hechang Chen, Lichao Sun, Bo Yang
+- [In-Context Reinforcement Learning Without Optimal Action Labels](https://openreview.net/forum?id=8Dey9wo2qA)
+  - Juncheng Dong, Moyang Guo, Ethan X Fang, Zhuoran Yang, Vahid Tarokh
+- [Can Large Language Models Explore In-Context?](https://arxiv.org/abs/2403.15371)
+  - Akshay Krishnamurthy, Keegan Harris, Dylan J. Foster, Cyril Zhang, Aleksandrs Slivkins
+- [Large Language Models As Evolution Strategies](https://arxiv.org/abs/2402.18381)
+  - Robert Tjarko Lange, Yingtao Tian, Yujin Tang
+### 2023
+- [Generalization to New Sequential Decision Making Tasks with In-Context Learning](https://arxiv.org/abs/2312.03801)
+  - Sharath Chandra Raparthy, Eric Hambro, Robert Kirk, Mikael Henaff, Roberta Raileanu
+- [Emergence of In-Context Reinforcement Learning from Noise Distillation](https://arxiv.org/abs/2312.12275)
+  - Ilya Zisman, Vladislav Kurenkov, Alexander Nikulin, Viacheslav Sinii, Sergey Kolesnikov 
+- [In-Context Reinforcement Learning for Variable Action Spaces](https://arxiv.org/abs/2312.13327)
+- [AMAGO: Scalable In-Context Reinforcement Learning for Adaptive Agents](https://arxiv.org/abs/2310.09971)
+  - Jake Grigsby, Linxi Fan, Yuke Zhu
+  - Viacheslav Sinii, Alexander Nikulin, Vladislav Kurenkov, Ilya Zisman, Sergey Kolesnikov
+- [Cross-Episodic Curriculum for Transformer Agents](https://arxiv.org/abs/2310.08549)
+  - Lucy Xiaoyang Shi, Yunfan Jiang, Jake Grigsby, Linxi "Jim" Fan, Yuke Zhu
+- [Transformers as Decision Makers: Provable In-Context Reinforcement Learning via Supervised Pretraining](https://arxiv.org/abs/2310.08566)
+  - Licong Lin, Yu Bai, Song Mei
+- [Large Language Models as General Pattern Machines](https://arxiv.org/abs/2307.04721)
+  - Suvir Mirchandani, Fei Xia, Pete Florence, Brian Ichter, Danny Driess, Montserrat Gonzalez Arenas, Kanishka Rao, Dorsa Sadigh, Andy Zeng
+- [First-Explore, then Exploit: Meta-Learning Intelligent Exploration](https://arxiv.org/abs/2307.02276)
+  - Ben Norman, Jeff Clune
+- [Supervised Pretraining Can Learn In-Context Reinforcement Learning](https://arxiv.org/abs/2306.14892)
+  - Jonathan N. Lee, Annie Xie, Aldo Pacchiano, Yash Chandak, Chelsea Finn, Ofir Nachum, Emma Brunskill
+- [Structured State Space Models for In-Context Reinforcement Learning](https://arxiv.org/abs/2303.03982)
+  - Chris Lu, Yannick Schroecker, Albert Gu, Emilio Parisotto, Jakob Foerster, Satinder Singh, Feryal Behbahani
+- [Human-Timescale Adaptation in an Open-Ended Task Space](https://arxiv.org/abs/2301.07608)
+  - Adaptive Agent Team, Jakob Bauer, Kate Baumli, Satinder Baveja, Feryal Behbahani, Avishkar Bhoopchand, Nathalie Bradley-Schmieg, Michael Chang, Natalie Clay, Adrian Collister, Vibhavari Dasagi, Lucy Gonzalez, Karol Gregor, Edward Hughes, Sheleem Kashem, Maria Loks-Thompson, Hannah Openshaw, Jack Parker-Holder, Shreya Pathak, Nicolas Perez-Nieves, Nemanja Rakicevic, Tim Rocktäschel, Yannick Schroecker, Jakub Sygnowski, Karl Tuyls, Sarah York, Alexander Zacherl, Lei Zhang
+- [Learning How to Infer Partial MDPs for In-Context Adaptation and Exploration](https://arxiv.org/abs/2302.04250)
+  - Chentian Jiang, Nan Rosemary Ke, Hado van Hasselt
+- [Towards General-Purpose In-Context Learning Agents](https://openreview.net/forum?id=zDTqQVGgzH)
+  - Louis Kirsch, James Harrison, C. Daniel Freeman, Jascha Sohl-Dickstein, Jürgen Schmidhuber
+### Before 2023
+- [In-context Reinforcement Learning with Algorithm Distillation](https://arxiv.org/abs/2210.14215)
+  - Michael Laskin, Luyu Wang, Junhyuk Oh, Emilio Parisotto, Stephen Spencer, Richie Steigerwald, DJ Strouse, Steven Hansen, Angelos Filos, Ethan Brooks, Maxime Gazeau, Himanshu Sahni, Satinder Singh, Volodymyr Mnih
+- [Large Language Models can Implement Policy Iteration](https://arxiv.org/abs/2210.03821)
+  - Ethan Brooks, Logan Walls, Richard L. Lewis, Satinder Singh
+### Publication Year Unkown


### PR DESCRIPTION
Display papers grouped under their publication year (e.g. “2025”, “2024”).
Helps readers quickly find the newest papers.